### PR TITLE
stop if can't reach server on first test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2050,7 +2050,7 @@ dependencies = [
 
 [[package]]
 name = "tasty"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tasty"
-version = "0.9.2"
+version = "0.9.3"
 authors = ["Jesse Lawson <jesse@lawsonry.com>"]
 edition = "2024"
 license = "GPL-3.0-or-later"

--- a/README.md
+++ b/README.md
@@ -169,6 +169,10 @@ myself of Rengoku as he was saying "tasty!" after each bite. And thus, _tasty_ w
 
 ## Changelog
 
+### 0.9.3
+
+* Stops testing if it can't reach the API server on the first test.
+
 ### 0.9.2
 
 * Corrected erroneous field name in readme

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -102,7 +102,7 @@ pub struct TestResult {
     pub feedback: Option<String>,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, PartialEq)]
 #[serde(rename_all = "lowercase")]
 pub enum TestStatus {
     Passed,
@@ -208,11 +208,9 @@ pub async fn run_test_case(
             Err(e) => {
                 test.outcome = Some(false);
                 test.feedback = Some(format!("Request failed: {}", e));
-                return Ok(());
+                return Err(e.into());
             }
     };
-
-    //println!("Response:\n{:?}", response);
 
     let status_matches = response.status().as_u16() == test.expect_http_status;
     let actual_status = response.status().as_u16();
@@ -329,6 +327,8 @@ pub async fn run_tests(args: &Args) -> Result<TestSuiteResult> {
                 .bold()
         );
 
+        let total_tests = &test_cases.len();
+
         for (test_name, case) in test_cases {
             let mut test: TestCase = case.try_into()?;
 
@@ -398,7 +398,20 @@ pub async fn run_tests(args: &Args) -> Result<TestSuiteResult> {
                 }
             };
 
-            results.push(result);
+            // If we can't run the first test, we likely can't run the rest of them.
+            // Bail out and let the user know:
+            match result.status {
+                TestStatus::Error => {
+                    // How many tests are left? 
+                    stats.skipped += total_tests - stats.total;
+                    println!("\n{}\n{}", "Failed to run a test (can the API server be reached?)".red(), 
+                        format!("Skipping {} remaining tests.", stats.skipped).yellow());
+                    break
+                },
+                _ => {
+                    results.push(result);
+                }
+            }
         }
     }
 


### PR DESCRIPTION
Now it will not try to run all the other tests if the first one has an error. 

This prevents a whole bunch of failed tests being ran in cases where no test can ever run (e.g., the API server is not reachable). 

**Example output**

![image](https://github.com/user-attachments/assets/8dc81e16-3134-48d6-8ed7-9d34a5b52745)
