### PR TITLE
v0.9.5 enhancements patch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2069,6 +2069,7 @@ dependencies = [
  "clap",
  "colored",
  "httpmock",
+ "regex",
  "reqwest",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -78,9 +78,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.96"
+version = "1.0.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b964d184e89d9b6b67dd2715bc8e74cf3107fb2b529990c90cf517326150bf4"
+checksum = "dcfed56ad506cb2c684a14971b8861fdc3baaaae314b9e5f9bb532cbe3ba7a4f"
 
 [[package]]
 name = "ascii-canvas"
@@ -175,7 +175,7 @@ dependencies = [
  "futures-lite",
  "parking",
  "polling",
- "rustix",
+ "rustix 0.38.44",
  "slab",
  "tracing",
  "windows-sys 0.59.0",
@@ -216,7 +216,7 @@ dependencies = [
  "cfg-if",
  "event-listener 5.4.0",
  "futures-lite",
- "rustix",
+ "rustix 0.38.44",
  "tracing",
 ]
 
@@ -232,7 +232,7 @@ dependencies = [
  "cfg-if",
  "futures-core",
  "futures-io",
- "rustix",
+ "rustix 0.38.44",
  "signal-hook-registry",
  "slab",
  "windows-sys 0.59.0",
@@ -274,13 +274,13 @@ checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
 name = "async-trait"
-version = "0.1.86"
+version = "0.1.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "644dd749086bf3771a2fbc5f256fdb982d53f011c7d5d560304eafeecebce79d"
+checksum = "d556ec1359574147ec0c4fc5eb525f3f23263a592b1a9c07e0a75b427de55c97"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -307,7 +307,7 @@ dependencies = [
  "miniz_oxide",
  "object",
  "rustc-demangle",
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -350,9 +350,9 @@ checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
 name = "bitflags"
-version = "2.8.0"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f68f53c83ab957f72c32642f3868eec03eb974d1fb82e453128456482613d36"
+checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
 
 [[package]]
 name = "blocking"
@@ -374,22 +374,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
 
 [[package]]
-name = "byteorder"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
-
-[[package]]
 name = "bytes"
-version = "1.10.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f61dac84819c6588b558454b194026eb1f09c293b9036ae9b159e74e73ab6cf9"
+checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "cc"
-version = "1.2.15"
+version = "1.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c736e259eea577f443d5c86c304f9f4ae0295c43f3ba05c21f1d66b5f06001af"
+checksum = "be714c154be609ec7f5dad223a33bf1482fff90472de28f7362806e6d4832b8c"
 dependencies = [
  "shlex",
 ]
@@ -408,9 +402,9 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "clap"
-version = "4.5.30"
+version = "4.5.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92b7b18d71fad5313a1e320fa9897994228ce274b60faa4d694fe0ea89cd9e6d"
+checksum = "6088f3ae8c3608d19260cd7445411865a485688711b78b5be70d78cd96136f83"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -418,9 +412,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.30"
+version = "4.5.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a35db2071778a7344791a4fb4f95308b5673d219dee3ae348b86642574ecc90c"
+checksum = "22a7ef7f676155edfb82daa97f99441f3ebf4a58d5e32f295a56259f1b6facc8"
 dependencies = [
  "anstream",
  "anstyle",
@@ -430,14 +424,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.28"
+version = "4.5.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf4ced95c6f4a675af3da73304b9ac4ed991640c36374e4b46795c49e17cf1ed"
+checksum = "09176aae279615badda0765c0c0b3f6ed53f4709118af73cf4655d85d1530cd7"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -528,14 +522,14 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.100",
 ]
 
 [[package]]
 name = "either"
-version = "1.13.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "ena"
@@ -682,7 +676,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -733,7 +727,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "wasi 0.13.3+wasi-0.2.2",
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -765,7 +759,7 @@ dependencies = [
  "fnv",
  "futures-core",
  "futures-sink",
- "http 1.2.0",
+ "http 1.3.1",
  "indexmap",
  "slab",
  "tokio",
@@ -804,9 +798,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.2.0"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f16ca2af56261c99fba8bac40a10251ce8188205a4c448fbb745a2e4daa76fea"
+checksum = "f4a85d31aea989eead29a3aaf9e1115a180df8282431156e533de47660892565"
 dependencies = [
  "bytes",
  "fnv",
@@ -831,27 +825,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http 1.2.0",
+ "http 1.3.1",
 ]
 
 [[package]]
 name = "http-body-util"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "793429d76616a256bcb62c2a2ec2bed781c8307e797e2598c50010f2bee2544f"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
- "futures-util",
- "http 1.2.0",
+ "futures-core",
+ "http 1.3.1",
  "http-body 1.0.1",
  "pin-project-lite",
 ]
 
 [[package]]
 name = "httparse"
-version = "1.10.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2d708df4e7140240a16cd6ab0ab65c972d7433ab77819ea693fde9c43811e2a"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
 name = "httpdate"
@@ -920,7 +914,7 @@ dependencies = [
  "futures-channel",
  "futures-util",
  "h2",
- "http 1.2.0",
+ "http 1.3.1",
  "http-body 1.0.1",
  "httparse",
  "itoa",
@@ -937,7 +931,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d191583f3da1305256f22463b9bb0471acad48a4e534a5218b9963e9c1f59b2"
 dependencies = [
  "futures-util",
- "http 1.2.0",
+ "http 1.3.1",
  "hyper 1.6.0",
  "hyper-util",
  "rustls",
@@ -973,7 +967,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "http 1.2.0",
+ "http 1.3.1",
  "http-body 1.0.1",
  "hyper 1.6.0",
  "pin-project-lite",
@@ -1098,7 +1092,7 @@ checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -1124,9 +1118,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.7.1"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c9c992b02b5b4c94ea26e32fe5bccb7aa7d9f390ab5c1221ff895bc7ea8b652"
+checksum = "3954d50fe15b02142bf25d3b8bdadb634ec3948f103d04ffe3031bc8fe9d7058"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -1155,9 +1149,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.14"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
+checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "js-sys"
@@ -1223,9 +1217,9 @@ checksum = "db13adb97ab515a3691f56e4dbab09283d0b86cb45abd991d8634a9d6f501760"
 
 [[package]]
 name = "libc"
-version = "0.2.169"
+version = "0.2.171"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
+checksum = "c19937216e9d3aa9956d9bb8dfc0b0c8beb6058fc4f7a4dc4d850edf86a237d6"
 
 [[package]]
 name = "libredox"
@@ -1244,10 +1238,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
-name = "litemap"
-version = "0.7.4"
+name = "linux-raw-sys"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ee93343901ab17bd981295f2cf0026d4ad018c7c31ba84549a4ddbb47a45104"
+checksum = "6db9c683daf087dc577b7506e9695b3d556a9f3849903fa28186283afd6809e9"
+
+[[package]]
+name = "litemap"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23fb14cb19457329c82206317a5663005a4d404783dc74f4252769b0d5f42856"
 
 [[package]]
 name = "lock_api"
@@ -1334,9 +1334,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.20.3"
+version = "1.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "945462a4b81e43c4e3ba96bd7b49d834c6f61198356aa858733bc4acf3cbe62e"
+checksum = "cde51589ab56b20a6f686b2c68f7a0bd6add753d697abf720d63f8db3ab7b1ad"
 
 [[package]]
 name = "openssl"
@@ -1361,7 +1361,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -1408,7 +1408,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -1467,9 +1467,9 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
+checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "polling"
@@ -1481,16 +1481,16 @@ dependencies = [
  "concurrent-queue",
  "hermit-abi",
  "pin-project-lite",
- "rustix",
+ "rustix 0.38.44",
  "tracing",
  "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.20"
+version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
 ]
@@ -1503,9 +1503,9 @@ checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.93"
+version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60946a68e5f9d28b0dc1c21bb8a97ee7d018a8b322fa57838ba31cc878e22d99"
+checksum = "a31971752e70b8b2686d7e46ec17fb38dad4051d94024c88df49b667caea9c84"
 dependencies = [
  "unicode-ident",
 ]
@@ -1523,7 +1523,7 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "socket2",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tokio",
  "tracing",
 ]
@@ -1542,7 +1542,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "tinyvec",
  "tracing",
  "web-time",
@@ -1550,9 +1550,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-udp"
-version = "0.5.9"
+version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c40286217b4ba3a71d644d752e6a0b71f13f1b6a2c5311acfcbe0c2418ed904"
+checksum = "e46f3055866785f6b92bc6164b76be02ca8f2eb4b002c0354b28cf4c119e5944"
 dependencies = [
  "cfg_aliases",
  "libc",
@@ -1564,9 +1564,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.38"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e4dccaaaf89514f546c693ddc140f729f958c247918a13380cccc6078391acc"
+checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
 dependencies = [
  "proc-macro2",
 ]
@@ -1603,9 +1603,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.9"
+version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82b568323e98e49e2a0899dcee453dd679fae22d69adf9b11dd508d1549b7e2f"
+checksum = "0b8c0c260b63a8219631167be35e6a988e9554dbd323f8bd08439c8ed1302bd1"
 dependencies = [
  "bitflags",
 ]
@@ -1652,9 +1652,9 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "reqwest"
-version = "0.12.12"
+version = "0.12.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43e734407157c3c2034e0258f5e4473ddb361b1e85f95a66690d67264d7cd1da"
+checksum = "389a89e494bbc88bebf30e23da98742c843863a16a352647716116aa71fae80a"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -1662,7 +1662,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2",
- "http 1.2.0",
+ "http 1.3.1",
  "http-body 1.0.1",
  "http-body-util",
  "hyper 1.6.0",
@@ -1701,9 +1701,9 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.17.10"
+version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d34b5020fcdea098ef7d95e9f89ec15952123a4a039badd09fabebe9e963e839"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
  "cfg-if",
@@ -1734,7 +1734,20 @@ dependencies = [
  "bitflags",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustix"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7178faa4b75a30e269c71e61c353ce2748cf3d76f0c44c393f4e60abf49b825"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.9.2",
  "windows-sys 0.59.0",
 ]
 
@@ -1783,15 +1796,15 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.19"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7c45b9784283f1b2e7fb61b42047c2fd678ef0960d4f6f1eba131594cc369d4"
+checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
 
 [[package]]
 name = "ryu"
-version = "1.0.19"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ea1a2d0a644769cc99faa24c3ad26b379b786fe7c36fd3c546254801650e6dd"
+checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
 name = "same-file"
@@ -1842,29 +1855,29 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.218"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8dfc9d19bdbf6d17e22319da49161d5d0108e4188e8b680aef6299eed22df60"
+checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.218"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f09503e191f4e797cb8aac08e9a4a4695c5edf6a2e70e376d961ddd5c969f82b"
+checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.100",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.139"
+version = "1.0.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44f86c3acccc9c65b153fe1b85a3be07fe5515274ec9f0653b4a0875731c72a6"
+checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
 dependencies = [
  "itoa",
  "memchr",
@@ -1998,9 +2011,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.98"
+version = "2.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36147f1a48ae0ec2b5b3bc5b537d267457555a10dc06f3dbc8cb11ba3006d3b1"
+checksum = "b09a44accad81e1ba1cd74a32461ba89dee89095ba17b32f5d03683b1b1fc2a0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2024,7 +2037,7 @@ checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -2050,7 +2063,7 @@ dependencies = [
 
 [[package]]
 name = "tasty"
-version = "0.9.4"
+version = "0.9.5"
 dependencies = [
  "anyhow",
  "clap",
@@ -2065,15 +2078,15 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.17.1"
+version = "3.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22e5a0acb1f3f55f65cc4a866c361b2fb2a0ff6366785ae6fbb5f85df07ba230"
+checksum = "2c317e0a526ee6120d8dabad239c8dadca62b24b6f168914bbbc8e2fb1f0e567"
 dependencies = [
  "cfg-if",
  "fastrand",
  "getrandom 0.3.1",
  "once_cell",
- "rustix",
+ "rustix 1.0.2",
  "windows-sys 0.59.0",
 ]
 
@@ -2099,11 +2112,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.11"
+version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d452f284b73e6d76dd36758a0c8684b1d5be31f92b89d07fd5822175732206fc"
+checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
 dependencies = [
- "thiserror-impl 2.0.11",
+ "thiserror-impl 2.0.12",
 ]
 
 [[package]]
@@ -2114,18 +2127,18 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.100",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.11"
+version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26afc1baea8a989337eeb52b6e72a039780ce45c3edfcc9c5b9d112feeb173c2"
+checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -2149,9 +2162,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.8.1"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "022db8904dfa342efe721985167e9fcd16c29b226db4397ed752a761cfce81e8"
+checksum = "09b3661f17e86524eccd4371ab0429194e0d7c008abb45f7a7495b1719463c71"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -2164,9 +2177,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.43.0"
+version = "1.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d61fa4ffa3de412bfea335c6ecff681de2b609ba3c77ef3e00e521813a9ed9e"
+checksum = "9975ea0f48b5aa3972bf2d888c238182458437cc2a19374b81b25cdf1023fb3a"
 dependencies = [
  "backtrace",
  "bytes",
@@ -2188,7 +2201,7 @@ checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -2203,9 +2216,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.26.1"
+version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6d0975eaace0cf0fcadee4e4aaa5da15b5c079146f2cffb67c113be122bf37"
+checksum = "8e727b36a1a0e8b74c376ac2211e40c2c8af09fb4013c60d910495810f008e9b"
 dependencies = [
  "rustls",
  "tokio",
@@ -2312,9 +2325,9 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00e2473a93778eb0bad35909dff6a10d28e63f792f16ed15e404fca9d5eeedbe"
+checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
 name = "unicode-xid"
@@ -2425,7 +2438,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.100",
  "wasm-bindgen-shared",
 ]
 
@@ -2460,7 +2473,7 @@ checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.100",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -2496,9 +2509,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.26.7"
+version = "0.26.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d642ff16b7e79272ae451b7322067cdc17cadf68c23264be9d94a32319efe7e"
+checksum = "2210b291f7ea53617fbafcc4939f10914214ec15aace5ba62293a668f322c5c9"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -2535,33 +2548,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
-name = "windows-registry"
-version = "0.2.0"
+name = "windows-link"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e400001bb720a623c1c69032f8e3e4cf09984deec740f007dd2b03ec864804b0"
+checksum = "6dccfd733ce2b1753b03b6d3c65edf020262ea35e20ccdf3e288043e6dd620e3"
+
+[[package]]
+name = "windows-registry"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4286ad90ddb45071efd1a66dfa43eb02dd0dfbae1545ad6cc3c51cf34d7e8ba3"
 dependencies = [
  "windows-result",
  "windows-strings",
- "windows-targets",
+ "windows-targets 0.53.0",
 ]
 
 [[package]]
 name = "windows-result"
-version = "0.2.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
+checksum = "06374efe858fab7e4f881500e6e86ec8bc28f9462c47e5a9941a0142ad86b189"
 dependencies = [
- "windows-targets",
+ "windows-link",
 ]
 
 [[package]]
 name = "windows-strings"
-version = "0.1.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
+checksum = "87fa48cc5d406560701792be122a10132491cff9d0aeb23583cc2dcafc847319"
 dependencies = [
- "windows-result",
- "windows-targets",
+ "windows-link",
 ]
 
 [[package]]
@@ -2570,7 +2588,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -2579,7 +2597,7 @@ version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -2588,14 +2606,30 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1e4c7e8ceaaf9cb7d7507c974735728ab453b67ef8f18febdd7c11fe59dca8b"
+dependencies = [
+ "windows_aarch64_gnullvm 0.53.0",
+ "windows_aarch64_msvc 0.53.0",
+ "windows_i686_gnu 0.53.0",
+ "windows_i686_gnullvm 0.53.0",
+ "windows_i686_msvc 0.53.0",
+ "windows_x86_64_gnu 0.53.0",
+ "windows_x86_64_gnullvm 0.53.0",
+ "windows_x86_64_msvc 0.53.0",
 ]
 
 [[package]]
@@ -2605,10 +2639,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2617,10 +2663,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -2629,10 +2687,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -2641,10 +2711,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
 name = "winnow"
@@ -2696,49 +2778,48 @@ checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.100",
  "synstructure",
 ]
 
 [[package]]
 name = "zerocopy"
-version = "0.7.35"
+version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
+checksum = "fd97444d05a4328b90e75e503a34bad781f14e28a823ad3557f0750df1ebcbc6"
 dependencies = [
- "byteorder",
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.7.35"
+version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+checksum = "6352c01d0edd5db859a63e2605f4ea3183ddbd15e2c4a9e7d32184df75e4f154"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.100",
 ]
 
 [[package]]
 name = "zerofrom"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cff3ee08c995dee1859d998dea82f7374f2826091dd9cd47def953cae446cd2e"
+checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "595eed982f7d355beb85837f651fa22e90b3c044842dc7f2c2842c086f295808"
+checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.100",
  "synstructure",
 ]
 
@@ -2767,5 +2848,5 @@ checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.98",
+ "syn 2.0.100",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,4 +16,5 @@ toml = "0.8.20"
 colored = "2"
 clap = { version = "4.5.30", features = ["derive"] }
 serde_json = "1.0.139"
+regex = "1.11"
 httpmock = "0.7.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tasty"
-version = "0.9.4"
+version = "0.9.5"
 authors = ["Jesse Lawson <jesse@lawsonry.com>"]
 edition = "2024"
 license = "GPL-3.0-or-later"
@@ -9,7 +9,7 @@ repository = "https://github.com/jesselawson/tasty"
 
 [dependencies]
 anyhow = "1.0.96"
-reqwest = { version = "0.12.12", features = ["json", "rustls-tls"] }
+reqwest = { version = "0.12.13", features = ["json", "rustls-tls"] }
 serde = { version = "1.0.218", features = ["derive"] }
 tokio = { version = "1.43.0", features = ["full"] }
 toml = "0.8.20"

--- a/README.md
+++ b/README.md
@@ -113,6 +113,20 @@ expect_http_status = 200
 expect_response_includes = { status = "ok" }
 ```
 
+Here's an example of the same test written in a different TOML syntax: 
+
+```toml
+# user_signup.toml
+
+[accept_valid_signup]
+method = "POST"
+route = "auth/signup"
+payload.email = "alice@example.com"
+payload.password = "This is a Valid Password!@t%"
+expect_http_status = 200
+expect_response_includes.status = "ok"
+```
+
 ### Test File Syntax
 
 Test files have the following properties that MUST be present 
@@ -171,7 +185,9 @@ myself of Rengoku as he was saying "tasty!" after each bite. And thus, _tasty_ w
 
 ### 0.9.5
 
-* Fixes an issue caused by deserializing JSON response values into a `Table` from the `toml` crate. Responses from test runs now use `serde_json::Value` semantics. 
+* Fixed an issue caused by deserializing JSON response values into a `Table` from the `toml` crate. Responses from test runs now use `serde_json::Value`.
+* Enforced declaration ordering of test runs. Previously, tests were running in alphabetical order according to the table key of the defined tests. Now they will run in the order in which they appear in the test files. 
+* Made `url` a flag rather than a positional argument.
 
 ### 0.9.4
 

--- a/README.md
+++ b/README.md
@@ -1,13 +1,15 @@
-# tasty! 🍰
+# Tasty is a TOML-based API testing tool
 
 **Tasty** is a command-line tool that runs API tests defined and grouped in TOML files.
+It has an opinionated syntax for writing and storing comprehensive API tests in a folder
+full of *.toml files.
 
 ## Status and Roadmap
 
-**Expect this project to be updated at least once or twice per month until `v1.0.0`.**
+**Expect this project to ship breaking changes until `v1.0.0`.**
 
-* Tasty is being built as a replacement for my bash scripts that I use for API testing. As I migrate features into Tasty, I'll release updates to this project. 
-* All releases will aim to be backwards-compatible. That includes keeping the way the testing files are written (e.g., using table keys as test names). 
+* Tasty is being built as a replacement for my bash scripts that I use for API testing. As I migrate features into Tasty, I'll release updates to this project.
+* All releases will aim to be backwards-compatible. That includes keeping the way the testing files are written (e.g., using table keys as test names).
 
 Right now, Tasty expects that you're working with the `application/json` content type only.
 
@@ -34,15 +36,16 @@ $ tasty --help
 
 Tasty, the API server testing tool
 
-Usage: tasty [OPTIONS] [URL] [TESTS]...
+Usage: tasty [OPTIONS] [TESTS]...
 
 Arguments:
-  [URL]       Base URL for the API (defaults to http://127.0.0.1:3030)
   [TESTS]...  Specific test files to run
 
 Options:
+  -b, --base-url <BASE_URL>       Base URL for the API (defaults to http://127.0.0.1:3030)
   -t, --tests-folder <FOLDER>     Custom tests folder path
   -g, --global-timeout <SECONDS>  Global timeout in seconds [default: 30]
+  -d, --debug                     Prints extra information on test run, including responses for passing tests
   -j, --json                      Output results as JSON (Not implemented yet)
   -h, --help                      Print help
   -V, --version                   Print version
@@ -50,7 +53,7 @@ Options:
 
 ### Examples
 
-Run all *.toml test files in your current working directory's 
+Run all *.toml test files in your current working directory's
 `/api_tests` folder against `http://localhost:3030`:
 
 ```bash
@@ -59,7 +62,7 @@ tasty
 
 ---
 
-Run all *.toml test files in your current working directory's 
+Run all *.toml test files in your current working directory's
 `/examples` folder against `http://localhost:3030`:
 
 ```bash
@@ -68,16 +71,16 @@ tasty -t examples
 
 ---
 
-Run all *.toml test files in your current working directory's 
+Run all *.toml test files in your current working directory's
 `/examples` folder against `https://api.example.com`:
 
-```bash 
+```bash
 tasty -t examples http://api.example.com
 ```
 
 ---
 
-Run just the `user_auth` test file in your current working 
+Run just the `user_auth` test file in your current working
 directory's `/api_tests` folder against `https://api.example.com`:
 
 ```bash
@@ -86,7 +89,7 @@ tasty -t api_tests https://api.example.com user_auth
 
 ---
 
-Run the `user_signup` and `auth_flow` test files in your current working 
+Run the `user_signup` and `auth_flow` test files in your current working
 directory's `/api_tests` folder against `http://staging-api.example.com`:
 
 ```bash
@@ -95,9 +98,9 @@ tasty http://staging-api.example.com user_signup auth_flow
 
 ## Writing Tests
 
-Tests are defined in and grouped by TOML files. If you have a 
-TOML file named `user_signup.toml`, all the tests in side that file 
-can be invoked with Tasty by passing it as a command-line argument. 
+Tests are defined in and grouped by TOML files. If you have a
+TOML file named `user_signup.toml`, all the tests in side that file
+can be invoked with Tasty by passing it as a command-line argument.
 
 Each test file can contain multiple test cases. Here's an example
 of a file with a single test case:
@@ -113,7 +116,7 @@ expect_http_status = 200
 expect_response_includes = { status = "ok" }
 ```
 
-Here's an example of the same test written in a different TOML syntax: 
+Here's an example of the same test written in a different TOML syntax:
 
 ```toml
 # user_signup.toml
@@ -129,12 +132,12 @@ expect_response_includes.status = "ok"
 
 ### Test File Syntax
 
-Test files have the following properties that MUST be present 
+Test files have the following properties that MUST be present
 in each table:
 
-* `name` _(Optional)_ The table key is the name of the test in the output report, 
-  but you can use this field if you'd like your table keys to be different from 
-  your test names. You might want this if you prefer the table keys in your TOML 
+* `name` _(Optional)_ The table key is the name of the test in the output report,
+  but you can use this field if you'd like your table keys to be different from
+  your test names. You might want this if you prefer the table keys in your TOML
   files to be organized differently than by the name of each test.
 * `method` The HTTP method to be used in the request
 * `route` The route to send the request to, not including the base URL
@@ -144,12 +147,12 @@ in each table:
 
 ## Participating & Contributing
 
-Contributions are welcome and encouraged. Please feel free to submit a Pull Request. 
+Contributions are welcome and encouraged. Please feel free to submit a Pull Request.
 For major changes, please open an issue first to discuss what you would like to change.
 
 ### Future Improvements
 
-While `tasty` is already useful for my purposes in its current form, I am open to 
+While `tasty` is already useful for my purposes in its current form, I am open to
 backwards-compatible enhancements that include (but are not limited to):
 
 - passing response values (like a a JWT) from one test to another
@@ -164,34 +167,34 @@ backwards-compatible enhancements that include (but are not limited to):
 
 ## License
 
-This project is licensed under the GNU General Public License version 3. See 
-the [LICENSE](LICENSE) file for details. 
+This project is licensed under the GNU General Public License version 3. See
+the [LICENSE](LICENSE) file for details.
 
 ## Lore
 
-The name `tasty!` comes from the English translation of the Japanese word "umai". 
+The name `tasty!` comes from the English translation of the Japanese word "umai".
 
-As I was building an API server, I found myself digging into a particularly 
-complex puzzle that involved asynchronous code and mutexes. At one point I was 
-making changes in one window and running my tests in another window, and as each 
-test completed I was saying _"delicious!"_. I'm not really sure why, but stay 
-with me. So in the Japanese manga series _Kimetsu no Yaiba_ ("Demon Slayer"), 
-there's a character named Rengoku who the protagonists find eating food and saying "umai!" 
-after each bite. (There's a whole backstory behind why he says this after each bite of 
-food, which I will not get into here). So I was running these tests and reminding 
-myself of Rengoku as he was saying "tasty!" after each bite. And thus, _tasty_ was born. 
+As I was building an API server, I found myself digging into a particularly
+complex puzzle that involved asynchronous code and mutexes. At one point I was
+making changes in one window and running my tests in another window, and as each
+test completed I was saying _"delicious!"_. I'm not really sure why, but stay
+with me. So in the Japanese manga series _Kimetsu no Yaiba_ ("Demon Slayer"),
+there's a character named Rengoku who the protagonists find eating food and saying "umai!"
+after each bite. (There's a whole backstory behind why he says this after each bite of
+food, which I will not get into here). So I was running these tests and reminding
+myself of Rengoku as he was saying "tasty!" after each bite. And thus, _tasty_ was born.
 
 ## Changelog
 
 ### 0.9.5
 
 * Fixed an issue caused by deserializing JSON response values into a `Table` from the `toml` crate. Responses from test runs now use `serde_json::Value`.
-* Enforced declaration ordering of test runs. Previously, tests were running in alphabetical order according to the table key of the defined tests. Now they will run in the order in which they appear in the test files. 
+* Enforced declaration ordering of test runs. Previously, tests were running in alphabetical order according to the table key of the defined tests. Now they will run in the order in which they appear in the test files.
 * Made `url` a flag rather than a positional argument.
 
 ### 0.9.4
 
-* The `-t` flag to provide a custom testing directory now correctly interprets relative paths. Before, passing `-t example` would not read from the `example` folder in the current working directory. Now, you can either specify a relative path or a full path. 
+* The `-t` flag to provide a custom testing directory now correctly interprets relative paths. Before, passing `-t example` would not read from the `example` folder in the current working directory. Now, you can either specify a relative path or a full path.
 * Continued improvements around output formatting, especially when the debug flag (`d`/`--debug`) is passed.
 
 ### 0.9.3
@@ -201,4 +204,4 @@ myself of Rengoku as he was saying "tasty!" after each bite. And thus, _tasty_ w
 ### 0.9.2
 
 * Corrected erroneous field name in readme
-* Added debug flag (`-d` or `--debug`) for the curious (and/or suspicious). 
+* Added debug flag (`-d` or `--debug`) for the curious (and/or suspicious).

--- a/README.md
+++ b/README.md
@@ -169,6 +169,10 @@ myself of Rengoku as he was saying "tasty!" after each bite. And thus, _tasty_ w
 
 ## Changelog
 
+### 0.9.5
+
+* Fixes an issue caused by deserializing JSON response values into a `Table` from the `toml` crate. Responses from test runs now use `serde_json::Value` semantics. 
+
 ### 0.9.4
 
 * The `-t` flag to provide a custom testing directory now correctly interprets relative paths. Before, passing `-t example` would not read from the `example` folder in the current working directory. Now, you can either specify a relative path or a full path. 

--- a/examples/error_cases.toml
+++ b/examples/error_cases.toml
@@ -2,12 +2,11 @@
 method = "GET"
 route = "api/timeout"
 payload = {}
-expect_http_status = 504
-expect_response_includes = {}
+expect.http_status = 504
 
 [test_bad_request]
 method = "POST"
 route = "api/items"
 payload = { invalid_field = true }
-expect_http_status = 400
-expect_response_includes = { error = "Invalid request body" }
+expect.http_status = 400
+expect.response = { error = "Invalid request body" }

--- a/examples/login_tests.toml
+++ b/examples/login_tests.toml
@@ -2,12 +2,12 @@
 method = "POST"
 route = "auth/login"
 payload = { username = "test_user", password = "correct_password" }
-expect_http_status = 200
-expect_response_includes = { token_type = "Bearer" }
+expect.http_status = 200
+expect.response = { token_type = "Bearer" }
 
 [test_failed_login]
 method = "POST"
 route = "auth/login"
 payload = { username = "test_user", password = "wrong_password" }
-expect_http_status = 401
-expect_response_includes = { error = "Invalid credentials" }
+expect.http_status = 401
+expect.response = { error = "Invalid credentials" }

--- a/examples/regex_matching.toml
+++ b/examples/regex_matching.toml
@@ -1,0 +1,16 @@
+# Test regex matching feature
+
+[test_regex_token]
+method = "POST"
+route = "auth/token"
+payload = { client_id = "test_client" }
+expect.http_status = 200
+expect.response = { token_type = "Bearer" }
+expect.response_regex = { access_token = "[a-zA-Z0-9_-]+" }
+
+[test_regex_user_id]
+method = "GET"
+route = "api/users/42"
+payload = {}
+expect.http_status = 200
+expect.response_regex = { id = "\\d+", email = ".*@.*\\..*" }

--- a/examples/response_reference.toml
+++ b/examples/response_reference.toml
@@ -1,0 +1,16 @@
+# Test response referencing feature
+# The second test uses the token from the first test's response
+
+[test_get_token]
+method = "POST"
+route = "auth/token"
+payload = { client_id = "test_client" }
+expect.http_status = 200
+expect.response = { token_type = "Bearer" }
+
+[test_use_token]
+method = "GET"
+route = "api/protected"
+payload.auth_token = { from = "test_get_token", property = "access_token" }
+expect.http_status = 200
+expect.response = { status = "authorized" }

--- a/examples/single_endpoint.toml
+++ b/examples/single_endpoint.toml
@@ -2,5 +2,5 @@
 method = "GET"
 route = "api/users/1"
 payload = {}
-expect_http_status = 200
-expect_response_includes = { id = 1, name = "Test User" }
+expect.http_status = 200
+expect.response = { id = 1, name = "Test User" }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -241,7 +241,7 @@ pub async fn run_test_case(
     let actual_status = response.status().as_u16();
 
     // Parse and validate response
-    let response_json: Table = match response.json::<Table>().await {
+    let response_json: serde_json::Value = match response.json().await {
         Ok(json) => json,
         Err(e) => {
             test.outcome = Some(false);
@@ -273,7 +273,13 @@ pub async fn run_test_case(
             // Verify that each expected key-value pair matches in the response
             expected
                 .iter()
-                .all(|(k, v)| response_json.get(k) == Some(v))
+                .all(|(k, v)| {
+                    if let Ok(json_v) = serde_json::to_value(v) {
+                        response_json.get(k) == Some(&json_v)
+                    } else {
+                        false
+                    }
+                })
         })
         .unwrap_or(true);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,6 +85,22 @@ pub struct TestCase {
     feedback: Option<String>,
 }
 
+/// Implicit conversion implementation to provide JSON intermediate represenation 
+/// for type casting as well as future export-to-json work
+impl TryFrom<&toml::Value> for TestCase {
+    type Error = anyhow::Error;
+    
+    fn try_from(value: &toml::Value) -> std::result::Result<Self, Self::Error> {
+        if let toml::Value::Table(_) = value {
+            let test_case: TestCase = serde_json::from_value(
+                serde_json::to_value(value)?
+            )?;
+            return Ok(test_case);
+        } 
+        Err(anyhow::anyhow!("Expected TOML table"))
+    }
+}
+
 #[derive(Debug, Clone, Copy, Default)]
 pub struct TestStats {
     pub total: usize,
@@ -137,6 +153,7 @@ impl Serialize for TestStats {
 
 static METHODS: [&str; 5] = ["POST", "GET", "PUT", "PATCH", "DELETE"];
 
+/// A helper function to print test results to the terminal window
 pub fn print_summary(stats: &TestStats) {
     println!("\nTest Summary:");
     println!("  Total tests: {}", stats.total);
@@ -144,6 +161,25 @@ pub fn print_summary(stats: &TestStats) {
     println!("  Failed: {}", stats.failed.to_string().red());
     println!("  Skipped: {}", stats.skipped.to_string().yellow());
     println!("  Total duration: {}ms", stats.total_duration.as_millis());
+}
+
+/// Scans the raw TOML content to extract table keys in the order they appear,
+/// providing a vec ready to be iterated through by the test runner
+fn extract_table_keys_order(content: &str) -> Vec<String> {
+    let mut keys = Vec::new();
+    for line in content.lines() {
+        let trimmed = line.trim();
+        if trimmed.starts_with('[') // Should start with a '['
+            && trimmed.ends_with(']') // Should end with a ']'
+            && !trimmed[1..].contains('[')
+        // Should not have s second '[' after pos 0
+        {
+            let key = trimmed[1..trimmed.len() - 1].to_string();
+            keys.push(key);
+        }
+    }
+
+    keys
 }
 
 pub fn get_test_files(args: &Args) -> Result<Vec<PathBuf>> {
@@ -174,7 +210,14 @@ pub fn get_test_files(args: &Args) -> Result<Vec<PathBuf>> {
         // Find all .toml files in the tests directory
         let read_dir = match fs::read_dir(&tests_dir) {
             Ok(d) => d,
-            Err(e) => return Err(anyhow::anyhow!("Unable to access the folder '{}'\n  (Got \"{}\")\nBe sure the folder exists and is readable. If you don't understand why you are getting this error, try the help command:\n    {}", &tests_dir.display(), e, "tasty --help".blue().bold()))
+            Err(e) => {
+                return Err(anyhow::anyhow!(
+                    "Unable to access the folder '{}'\n  (Got \"{}\")\nBe sure the folder exists and is readable. If you don't understand why you are getting this error, try the help command:\n    {}",
+                    &tests_dir.display(),
+                    e,
+                    "tasty --help".blue().bold()
+                ));
+            }
         };
 
         for entry in read_dir {
@@ -245,8 +288,10 @@ pub async fn run_test_case(
         Ok(json) => json,
         Err(e) => {
             test.outcome = Some(false);
-            test.feedback = Some(format!("    HTTP Response: {}\n      Error: {}", 
-                &response_status, e));
+            test.feedback = Some(format!(
+                "    HTTP Response: {}\n      Error: {}",
+                &response_status, e
+            ));
             return Ok(());
         }
     };
@@ -271,15 +316,13 @@ pub async fn run_test_case(
         .as_ref()
         .map(|expected| {
             // Verify that each expected key-value pair matches in the response
-            expected
-                .iter()
-                .all(|(k, v)| {
-                    if let Ok(json_v) = serde_json::to_value(v) {
-                        response_json.get(k) == Some(&json_v)
-                    } else {
-                        false
-                    }
-                })
+            expected.iter().all(|(k, v)| {
+                if let Ok(json_v) = serde_json::to_value(v) {
+                    response_json.get(k) == Some(&json_v)
+                } else {
+                    false
+                }
+            })
         })
         .unwrap_or(true);
 
@@ -377,126 +420,133 @@ pub async fn run_tests(args: &Args) -> Result<TestSuiteResult> {
 
         let total_tests = &test_cases.len();
 
-        for (test_name, case) in test_cases {
-            let mut test: TestCase = case.try_into()?;
+        let ordered_keys = extract_table_keys_order(&content);
 
-            // Use the table key as the test name if none was provided
-            if test.name.is_empty() {
-                test.name = test_name;
-            }
-            stats.total += 1;
+        for key in ordered_keys {
+            if let Some(case) = test_cases.get(&key) {
+                let mut test: TestCase = case.try_into()?;
 
-            if !args.debug {
-                print!("  {} ... ", test.name);
-            } else {
-                println!(
-                    "{}",
-                    format!(
-                        "{} {}\n{}\n",
-                        &test.name.blue().dimmed().bold(),
-                        "definition".blue().dimmed(),
-                        serde_json::to_string_pretty(&test).unwrap().dimmed()
-                    )
-                );
-            }
-
-            let result = if let Err(e) = run_test_case(&client, &base_url, &mut test, &args).await {
-                println!("{}", "ERROR".red());
-                println!("    {}", e);
-
-                stats.failed += 1;
-                TestResult {
-                    name: test.name,
-                    status: TestStatus::Error,
-                    duration_ms: None,
-                    feedback: Some(format!("    {}\n", e.to_string().dimmed().red())),
+                // Use the table key as the test name if none was provided
+                if test.name.is_empty() {
+                    test.name = key;
                 }
-            } else {
-                match test.outcome {
-                    Some(true) => {
-                        if args.debug {
-                            println!(
-                                "{}\n{}",
-                                format!(
+                stats.total += 1;
+
+                if !args.debug {
+                    print!("  {} ... ", test.name);
+                } else {
+                    println!(
+                        "{}",
+                        format!(
+                            "{} {}\n{}\n",
+                            &test.name.blue().dimmed().bold(),
+                            "definition".blue().dimmed(),
+                            serde_json::to_string_pretty(&test).unwrap().dimmed()
+                        )
+                    );
+                }
+
+                let result = if let Err(e) =
+                    run_test_case(&client, &base_url, &mut test, &args).await
+                {
+                    println!("{}", "ERROR".red());
+                    println!("    {}", e);
+
+                    stats.failed += 1;
+                    TestResult {
+                        name: test.name,
+                        status: TestStatus::Error,
+                        duration_ms: None,
+                        feedback: Some(format!("    {}\n", e.to_string().dimmed().red())),
+                    }
+                } else {
+                    match test.outcome {
+                        Some(true) => {
+                            if args.debug {
+                                println!(
+                                    "{}\n{}",
+                                    format!(
+                                        "{} {}",
+                                        &test.name.blue().dimmed().bold(),
+                                        "outcome".blue().dimmed(),
+                                    ),
+                                    format!(
+                                        "    {} {}",
+                                        "ok".green(),
+                                        format!("({}ms)", test.duration.unwrap().as_millis())
+                                            .dimmed()
+                                    )
+                                );
+                            } else {
+                                println!(
                                     "{} {}",
-                                    &test.name.blue().dimmed().bold(),
-                                    "outcome".blue().dimmed(),
-                                ),
-                                format!(
-                                    "    {} {}",
                                     "ok".green(),
                                     format!("({}ms)", test.duration.unwrap().as_millis()).dimmed()
-                                )
-                            );
-                        } else {
-                            println!(
-                                "{} {}",
-                                "ok".green(),
-                                format!("({}ms)", test.duration.unwrap().as_millis()).dimmed()
-                            );
-                        }
+                                );
+                            }
 
-                        stats.passed += 1;
-                        TestResult {
-                            name: test.name,
-                            status: TestStatus::Passed,
-                            duration_ms: Some(test.duration.unwrap().as_millis()),
-                            feedback: None,
+                            stats.passed += 1;
+                            TestResult {
+                                name: test.name,
+                                status: TestStatus::Passed,
+                                duration_ms: Some(test.duration.unwrap().as_millis()),
+                                feedback: None,
+                            }
+                        }
+                        Some(false) => {
+                            if args.debug {
+                                println!(
+                                    "{}\n{}",
+                                    format!(
+                                        "{} {}",
+                                        &test.name.blue().dimmed().bold(),
+                                        "outcome".blue().dimmed(),
+                                    ),
+                                    "    failed".red()
+                                );
+                            } else {
+                                println!("{}", "failed".red());
+                            }
+                            println!("{}", test.feedback.as_ref().unwrap());
+
+                            stats.failed += 1;
+                            TestResult {
+                                name: test.name,
+                                status: TestStatus::Failed,
+                                duration_ms: None,
+                                feedback: test.feedback,
+                            }
+                        }
+                        None => {
+                            println!("{}", "SKIPPED".yellow());
+
+                            stats.skipped += 1;
+                            TestResult {
+                                name: test.name,
+                                status: TestStatus::Skipped,
+                                duration_ms: None,
+                                feedback: None,
+                            }
                         }
                     }
-                    Some(false) => {
-                        if args.debug {
-                            println!(
-                                "{}\n{}",
-                                format!(
-                                    "{} {}",
-                                    &test.name.blue().dimmed().bold(),
-                                    "outcome".blue().dimmed(),
-                                ),
-                                "    failed".red()
-                            );
-                        } else {
-                            println!("{}", "failed".red());
-                        }
-                        println!("{}", test.feedback.as_ref().unwrap());
+                };
 
-                        stats.failed += 1;
-                        TestResult {
-                            name: test.name,
-                            status: TestStatus::Failed,
-                            duration_ms: None,
-                            feedback: test.feedback,
-                        }
+                // If we can't run the first test, we likely can't run the rest of them.
+                // Bail out and let the user know:
+                match result.status {
+                    TestStatus::Error => {
+                        // How many tests are left?
+                        stats.skipped += total_tests - stats.total;
+                        println!(
+                            "\n{}\n{}",
+                            "Failed to run a test (can the API server be reached?)".red(),
+                            format!("Skipping {} remaining tests.", stats.skipped).yellow()
+                        );
+                        break;
                     }
-                    None => {
-                        println!("{}", "SKIPPED".yellow());
-
-                        stats.skipped += 1;
-                        TestResult {
-                            name: test.name,
-                            status: TestStatus::Skipped,
-                            duration_ms: None,
-                            feedback: None,
-                        }
+                    _ => {
+                        results.push(result);
                     }
-                }
-            };
-
-            // If we can't run the first test, we likely can't run the rest of them.
-            // Bail out and let the user know:
-            match result.status {
-                TestStatus::Error => {
-                    // How many tests are left?
-                    stats.skipped += total_tests - stats.total;
-                    println!(
-                        "\n{}\n{}",
-                        "Failed to run a test (can the API server be reached?)".red(),
-                        format!("Skipping {} remaining tests.", stats.skipped).yellow()
-                    );
-                    break;
-                }
-                _ => {
-                    results.push(result);
                 }
             }
         }
@@ -545,13 +595,11 @@ mod tests {
         };
 
         let files = get_test_files(&args)?;
-
-        assert!(
-            files.contains(&PathBuf::from("examples/single_endpoint.toml")),
-            "actual: {:?}",
-            files
-        );
-        assert!(files.contains(&PathBuf::from("examples/login_tests.toml")));
+        
+        assert!(files.iter().any(|f| f.ends_with("examples/error_cases.toml")));
+        assert!(files.iter().any(|f| f.ends_with("examples/login_tests.toml")));
+        assert!(files.iter().any(|f| f.ends_with("examples/single_endpoint.toml")));
+        
         Ok(())
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,12 +17,8 @@ use toml::Table;
 #[command(author, version, about = format!("{}, the API server testing tool", "Tasty".bold()))]
 pub struct Args {
     /// Base URL for the API (defaults to http://127.0.0.1:3030)
-    #[arg(value_name = "URL")]
+    #[arg(short = 'b', long = "base-url", value_name = "BASE_URL")]
     pub base_url: Option<String>,
-
-    /// Specific test files to run
-    #[arg(value_name = "TESTS")]
-    pub test_files: Vec<String>,
 
     /// Custom tests folder path
     #[arg(short = 't', long = "tests-folder", value_name = "FOLDER")]
@@ -45,6 +41,10 @@ pub struct Args {
     /// Output results as JSON (Not implemented yet)
     #[arg(short = 'j', long = "json")]
     pub json: bool,
+
+    /// Specific test files to run
+    #[arg(value_name = "TESTS")]
+    pub test_files: Vec<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,9 +4,11 @@
 use anyhow::{Context, Result};
 use clap::Parser;
 use colored::*;
+use regex::Regex;
 use reqwest::Client;
 use serde::{Deserialize, Serialize};
 use std::{
+    collections::HashMap,
     fs,
     path::PathBuf,
     time::{Duration, Instant},
@@ -47,6 +49,34 @@ pub struct Args {
     pub test_files: Vec<String>,
 }
 
+/// Configuration for test expectations
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct ExpectConfig {
+    /// The HTTP status code expected for a passing test
+    pub http_status: u16,
+
+    /// Properties expected in the response object (literal matching)
+    #[serde(default)]
+    pub response: Option<Table>,
+
+    /// Properties expected in the response object (regex matching)
+    #[serde(default)]
+    pub response_regex: Option<Table>,
+
+    /// Properties expected in response headers (future use)
+    #[serde(default)]
+    pub headers: Option<Table>,
+}
+
+/// Represents a reference to a value from a previous test's response
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct ValueReference {
+    /// The name of the test to reference
+    pub from: String,
+    /// The property path to extract (e.g., "response.access_token")
+    pub property: String,
+}
+
 #[derive(Debug, Serialize, Deserialize)]
 pub struct TestCase {
     /// The name of the test, set from the toml table key value if not explicitly provided
@@ -62,13 +92,10 @@ pub struct TestCase {
 
     /// The data payload to send as part of the request.
     /// It will be in `application/json` format.
-    pub payload: Table,
+    pub payload: serde_json::Value,
 
-    /// The HTTP status code expected for a passing test
-    pub expect_http_status: u16,
-
-    /// Properties expected in the response object
-    pub expect_response_includes: Option<Table>,
+    /// Test expectations configuration
+    pub expect: ExpectConfig,
 
     /// `None` The test hasn't run yet
     /// `true` The test passed
@@ -152,6 +179,195 @@ impl Serialize for TestStats {
 }
 
 static METHODS: [&str; 5] = ["POST", "GET", "PUT", "PATCH", "DELETE"];
+
+/// Extracts a nested value from a JSON Value using dot notation.
+/// For example, "response.user.id" would traverse response -> user -> id.
+fn get_nested_value<'a>(value: &'a serde_json::Value, path: &str) -> Option<&'a serde_json::Value> {
+    let parts: Vec<&str> = path.split('.').collect();
+    let mut current = value;
+
+    for part in parts {
+        current = current.get(part)?;
+    }
+
+    Some(current)
+}
+
+/// Checks if a value is a reference object (has "from" and "property" fields)
+fn is_value_reference(value: &serde_json::Value) -> bool {
+    if let serde_json::Value::Object(obj) = value {
+        obj.contains_key("from") && obj.contains_key("property") && obj.len() == 2
+    } else {
+        false
+    }
+}
+
+/// Resolves all value references in a payload using stored responses from previous tests.
+/// Returns an error if a referenced test doesn't exist or the property path is invalid.
+fn resolve_payload_references(
+    payload: &mut serde_json::Value,
+    responses: &HashMap<String, serde_json::Value>,
+) -> Result<()> {
+    match payload {
+        serde_json::Value::Object(obj) => {
+            let keys: Vec<String> = obj.keys().cloned().collect();
+            for key in keys {
+                if let Some(value) = obj.get(&key) {
+                    if is_value_reference(value) {
+                        // Extract reference info
+                        let from = value.get("from")
+                            .and_then(|v| v.as_str())
+                            .ok_or_else(|| anyhow::anyhow!("Invalid 'from' field in reference"))?;
+                        let property = value.get("property")
+                            .and_then(|v| v.as_str())
+                            .ok_or_else(|| anyhow::anyhow!("Invalid 'property' field in reference"))?;
+
+                        // Look up the referenced response
+                        let referenced_response = responses.get(from)
+                            .ok_or_else(|| anyhow::anyhow!(
+                                "Referenced test '{}' not found. Make sure the test exists and ran successfully before this test.",
+                                from
+                            ))?;
+
+                        // Extract the nested value
+                        let resolved_value = get_nested_value(referenced_response, property)
+                            .ok_or_else(|| anyhow::anyhow!(
+                                "Property path '{}' not found in response from test '{}'",
+                                property, from
+                            ))?
+                            .clone();
+
+                        // Replace the reference with the resolved value
+                        obj.insert(key, resolved_value);
+                    } else {
+                        // Recursively process nested objects/arrays
+                        if let Some(nested) = obj.get_mut(&key) {
+                            resolve_payload_references(nested, responses)?;
+                        }
+                    }
+                }
+            }
+        }
+        serde_json::Value::Array(arr) => {
+            for item in arr.iter_mut() {
+                resolve_payload_references(item, responses)?;
+            }
+        }
+        _ => {}
+    }
+    Ok(())
+}
+
+/// Validates response against literal expected values.
+/// Returns Ok(true) if all expectations match, Ok(false) with feedback if mismatch.
+fn validate_response_literal(
+    response: &serde_json::Value,
+    expected: &Table,
+) -> (bool, Option<String>) {
+    let mut mismatches = Vec::new();
+
+    for (key, expected_value) in expected.iter() {
+        let expected_json: serde_json::Value = match serde_json::to_value(expected_value) {
+            Ok(v) => v,
+            Err(_) => {
+                mismatches.push(format!("Failed to convert expected value for key '{}'", key));
+                continue;
+            }
+        };
+
+        // Support dot notation for nested access
+        let actual_value = get_nested_value(response, key);
+
+        match actual_value {
+            Some(actual) if actual == &expected_json => {
+                // Match - continue
+            }
+            Some(actual) => {
+                mismatches.push(format!(
+                    "Key '{}': expected '{}', got '{}'",
+                    key,
+                    expected_json,
+                    actual
+                ));
+            }
+            None => {
+                mismatches.push(format!(
+                    "Key '{}': expected '{}', but key not found in response",
+                    key,
+                    expected_json
+                ));
+            }
+        }
+    }
+
+    if mismatches.is_empty() {
+        (true, None)
+    } else {
+        (false, Some(mismatches.join("\n")))
+    }
+}
+
+/// Validates response against regex patterns.
+/// Returns Ok(true) if all patterns match, Ok(false) with feedback if mismatch.
+fn validate_response_regex(
+    response: &serde_json::Value,
+    patterns: &Table,
+) -> (bool, Option<String>) {
+    let mut mismatches = Vec::new();
+
+    for (key, pattern_value) in patterns.iter() {
+        let pattern_str = match pattern_value.as_str() {
+            Some(s) => s,
+            None => {
+                mismatches.push(format!("Regex pattern for key '{}' must be a string", key));
+                continue;
+            }
+        };
+
+        let regex = match Regex::new(pattern_str) {
+            Ok(r) => r,
+            Err(e) => {
+                mismatches.push(format!("Invalid regex pattern for key '{}': {}", key, e));
+                continue;
+            }
+        };
+
+        // Support dot notation for nested access
+        let actual_value = get_nested_value(response, key);
+
+        match actual_value {
+            Some(actual) => {
+                // Convert the actual value to a string for regex matching
+                let actual_str = match actual {
+                    serde_json::Value::String(s) => s.clone(),
+                    serde_json::Value::Number(n) => n.to_string(),
+                    serde_json::Value::Bool(b) => b.to_string(),
+                    serde_json::Value::Null => "null".to_string(),
+                    _ => actual.to_string(),
+                };
+
+                if !regex.is_match(&actual_str) {
+                    mismatches.push(format!(
+                        "Key '{}': value '{}' does not match pattern '{}'",
+                        key, actual_str, pattern_str
+                    ));
+                }
+            }
+            None => {
+                mismatches.push(format!(
+                    "Key '{}': expected to match pattern '{}', but key not found in response",
+                    key, pattern_str
+                ));
+            }
+        }
+    }
+
+    if mismatches.is_empty() {
+        (true, None)
+    } else {
+        (false, Some(mismatches.join("\n")))
+    }
+}
 
 /// A helper function to print test results to the terminal window
 pub fn print_summary(stats: &TestStats) {
@@ -251,7 +467,8 @@ pub async fn run_test_case(
     base_url: &str,
     test: &mut TestCase,
     args: &Args,
-) -> Result<()> {
+    responses: &HashMap<String, serde_json::Value>,
+) -> Result<Option<serde_json::Value>> {
     let start_time = Instant::now();
     let url = format!("{}/{}", base_url.trim_end_matches('/'), test.route);
 
@@ -259,13 +476,21 @@ pub async fn run_test_case(
     if !METHODS.iter().any(|m| test.method.contains(m)) {
         test.outcome = Some(false);
         test.feedback = Some(format!("Invalid HTTP method: {}", test.method));
-        return Ok(());
+        return Ok(None);
+    }
+
+    // Resolve any payload references from previous test responses
+    let mut payload = test.payload.clone();
+    if let Err(e) = resolve_payload_references(&mut payload, responses) {
+        test.outcome = Some(false);
+        test.feedback = Some(format!("    {}\n    {}", "Reference resolution failed:".bold(), e));
+        return Ok(None);
     }
 
     // Execute the request
     let response = match client
         .request(test.method.parse()?, &url)
-        .json(&test.payload)
+        .json(&payload)
         .timeout(Duration::from_secs_f64(args.timeout as f64))
         .send()
         .await
@@ -280,7 +505,7 @@ pub async fn run_test_case(
 
     let response_status = response.status().clone();
 
-    let status_matches = response.status().as_u16() == test.expect_http_status;
+    let status_matches = response.status().as_u16() == test.expect.http_status;
     let actual_status = response.status().as_u16();
 
     // Parse and validate response
@@ -292,7 +517,7 @@ pub async fn run_test_case(
                 "    HTTP Response: {}\n      Error: {}",
                 &response_status, e
             ));
-            return Ok(());
+            return Ok(None);
         }
     };
 
@@ -308,27 +533,25 @@ pub async fn run_test_case(
         );
     }
 
-    // Now check our payload expectations:
-    // Do all expected kv pairs exist in the response?
-    // If no expectations were provided (None), consider it a match (true):
-    let payload_matches = test
-        .expect_response_includes
+    // Validate literal response expectations
+    let (literal_matches, literal_feedback) = test
+        .expect
+        .response
         .as_ref()
-        .map(|expected| {
-            // Verify that each expected key-value pair matches in the response
-            expected.iter().all(|(k, v)| {
-                if let Ok(json_v) = serde_json::to_value(v) {
-                    response_json.get(k) == Some(&json_v)
-                } else {
-                    false
-                }
-            })
-        })
-        .unwrap_or(true);
+        .map(|expected| validate_response_literal(&response_json, expected))
+        .unwrap_or((true, None));
+
+    // Validate regex response expectations
+    let (regex_matches, regex_feedback) = test
+        .expect
+        .response_regex
+        .as_ref()
+        .map(|patterns| validate_response_regex(&response_json, patterns))
+        .unwrap_or((true, None));
 
     // Record test results
     test.duration = Some(start_time.elapsed());
-    test.outcome = Some(status_matches && payload_matches);
+    test.outcome = Some(status_matches && literal_matches && regex_matches);
 
     if !test.outcome.unwrap() {
         let mut feedback = Vec::new();
@@ -337,22 +560,17 @@ pub async fn run_test_case(
             feedback.push(format!(
                 "    {}\n    Expected: {}\n    Returned: {}",
                 "Status code mismatch:".bold(),
-                test.expect_http_status.to_string().dimmed(),
+                test.expect.http_status.to_string().dimmed(),
                 actual_status.to_string().dimmed()
             ));
         }
 
-        if !payload_matches {
+        if !literal_matches {
             feedback.push(format!(
-                "    {}\n    Expected: \n{}\n    Returned: \n{}",
-                "Payload mismatch:".bold(),
-                (serde_json::to_string_pretty(&test.expect_response_includes).unwrap())
-                    .lines()
-                    .map(|l| format!("      {}", l))
-                    .collect::<Vec<String>>()
-                    .join("\n")
-                    .dimmed(),
-                (serde_json::to_string_pretty(&response_json).unwrap())
+                "    {}\n{}",
+                "Literal expectation mismatch:".bold(),
+                literal_feedback
+                    .unwrap_or_default()
                     .lines()
                     .map(|l| format!("      {}", l))
                     .collect::<Vec<String>>()
@@ -361,10 +579,37 @@ pub async fn run_test_case(
             ));
         }
 
+        if !regex_matches {
+            feedback.push(format!(
+                "    {}\n{}",
+                "Regex expectation mismatch:".bold(),
+                regex_feedback
+                    .unwrap_or_default()
+                    .lines()
+                    .map(|l| format!("      {}", l))
+                    .collect::<Vec<String>>()
+                    .join("\n")
+                    .dimmed()
+            ));
+        }
+
+        // Also show the actual response for debugging
+        feedback.push(format!(
+            "    {}\n{}",
+            "Actual response:".bold(),
+            serde_json::to_string_pretty(&response_json)
+                .unwrap()
+                .lines()
+                .map(|l| format!("      {}", l))
+                .collect::<Vec<String>>()
+                .join("\n")
+                .dimmed()
+        ));
+
         test.feedback = Some(feedback.join("\n"));
     }
 
-    Ok(())
+    Ok(Some(response_json))
 }
 
 pub async fn run_tests(args: &Args) -> Result<TestSuiteResult> {
@@ -391,6 +636,7 @@ pub async fn run_tests(args: &Args) -> Result<TestSuiteResult> {
     let test_files = get_test_files(&args)?;
     let mut stats = TestStats::default();
     let mut results: Vec<TestResult> = Vec::new();
+    let mut responses: HashMap<String, serde_json::Value> = HashMap::new();
     let suite_start = Instant::now();
 
     // Handle case where no test files were found
@@ -446,53 +692,59 @@ pub async fn run_tests(args: &Args) -> Result<TestSuiteResult> {
                     );
                 }
 
-                let result = if let Err(e) =
-                    run_test_case(&client, &base_url, &mut test, &args).await
-                {
-                    println!("{}", "ERROR".red());
-                    println!("    {}", e);
+                let test_name = test.name.clone();
+                let result = match run_test_case(&client, &base_url, &mut test, &args, &responses).await {
+                    Err(e) => {
+                        println!("{}", "ERROR".red());
+                        println!("    {}", e);
 
-                    stats.failed += 1;
-                    TestResult {
-                        name: test.name,
-                        status: TestStatus::Error,
-                        duration_ms: None,
-                        feedback: Some(format!("    {}\n", e.to_string().dimmed().red())),
-                    }
-                } else {
-                    match test.outcome {
-                        Some(true) => {
-                            if args.debug {
-                                println!(
-                                    "{}\n{}",
-                                    format!(
-                                        "{} {}",
-                                        &test.name.blue().dimmed().bold(),
-                                        "outcome".blue().dimmed(),
-                                    ),
-                                    format!(
-                                        "    {} {}",
-                                        "ok".green(),
-                                        format!("({}ms)", test.duration.unwrap().as_millis())
-                                            .dimmed()
-                                    )
-                                );
-                            } else {
-                                println!(
-                                    "{} {}",
-                                    "ok".green(),
-                                    format!("({}ms)", test.duration.unwrap().as_millis()).dimmed()
-                                );
-                            }
-
-                            stats.passed += 1;
-                            TestResult {
-                                name: test.name,
-                                status: TestStatus::Passed,
-                                duration_ms: Some(test.duration.unwrap().as_millis()),
-                                feedback: None,
-                            }
+                        stats.failed += 1;
+                        TestResult {
+                            name: test.name,
+                            status: TestStatus::Error,
+                            duration_ms: None,
+                            feedback: Some(format!("    {}\n", e.to_string().dimmed().red())),
                         }
+                    }
+                    Ok(response_json) => {
+                        // Store the response for potential reference by later tests
+                        if let Some(json) = response_json {
+                            responses.insert(test_name.clone(), json);
+                        }
+
+                        match test.outcome {
+                            Some(true) => {
+                                if args.debug {
+                                    println!(
+                                        "{}\n{}",
+                                        format!(
+                                            "{} {}",
+                                            &test.name.blue().dimmed().bold(),
+                                            "outcome".blue().dimmed(),
+                                        ),
+                                        format!(
+                                            "    {} {}",
+                                            "ok".green(),
+                                            format!("({}ms)", test.duration.unwrap().as_millis())
+                                                .dimmed()
+                                        )
+                                    );
+                                } else {
+                                    println!(
+                                        "{} {}",
+                                        "ok".green(),
+                                        format!("({}ms)", test.duration.unwrap().as_millis()).dimmed()
+                                    );
+                                }
+
+                                stats.passed += 1;
+                                TestResult {
+                                    name: test.name,
+                                    status: TestStatus::Passed,
+                                    duration_ms: Some(test.duration.unwrap().as_millis()),
+                                    feedback: None,
+                                }
+                            }
                         Some(false) => {
                             if args.debug {
                                 println!(
@@ -528,6 +780,7 @@ pub async fn run_tests(args: &Args) -> Result<TestSuiteResult> {
                                 feedback: None,
                             }
                         }
+                    }
                     }
                 };
 
@@ -595,11 +848,179 @@ mod tests {
         };
 
         let files = get_test_files(&args)?;
-        
+
         assert!(files.iter().any(|f| f.ends_with("examples/error_cases.toml")));
         assert!(files.iter().any(|f| f.ends_with("examples/login_tests.toml")));
         assert!(files.iter().any(|f| f.ends_with("examples/single_endpoint.toml")));
-        
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_get_nested_value() {
+        let json = serde_json::json!({
+            "user": {
+                "profile": {
+                    "name": "John",
+                    "age": 30
+                },
+                "id": 123
+            },
+            "token": "abc123"
+        });
+
+        // Test simple key access
+        assert_eq!(get_nested_value(&json, "token"), Some(&serde_json::json!("abc123")));
+
+        // Test nested key access
+        assert_eq!(get_nested_value(&json, "user.id"), Some(&serde_json::json!(123)));
+        assert_eq!(get_nested_value(&json, "user.profile.name"), Some(&serde_json::json!("John")));
+        assert_eq!(get_nested_value(&json, "user.profile.age"), Some(&serde_json::json!(30)));
+
+        // Test non-existent key
+        assert_eq!(get_nested_value(&json, "nonexistent"), None);
+        assert_eq!(get_nested_value(&json, "user.nonexistent"), None);
+    }
+
+    #[test]
+    fn test_validate_response_literal() {
+        let response = serde_json::json!({
+            "status": "ok",
+            "code": 200,
+            "data": {
+                "id": 1,
+                "name": "Test"
+            }
+        });
+
+        // Test matching values
+        let mut expected = Table::new();
+        expected.insert("status".to_string(), toml::Value::String("ok".to_string()));
+        let (matches, feedback) = validate_response_literal(&response, &expected);
+        assert!(matches, "Should match: {:?}", feedback);
+
+        // Test non-matching values
+        let mut expected = Table::new();
+        expected.insert("status".to_string(), toml::Value::String("error".to_string()));
+        let (matches, feedback) = validate_response_literal(&response, &expected);
+        assert!(!matches, "Should not match");
+        assert!(feedback.is_some());
+
+        // Test nested access with dot notation
+        let mut expected = Table::new();
+        expected.insert("data.id".to_string(), toml::Value::Integer(1));
+        let (matches, feedback) = validate_response_literal(&response, &expected);
+        assert!(matches, "Should match nested: {:?}", feedback);
+    }
+
+    #[test]
+    fn test_validate_response_regex() {
+        let response = serde_json::json!({
+            "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9",
+            "user_id": 12345,
+            "email": "test@example.com"
+        });
+
+        // Test matching regex patterns
+        let mut patterns = Table::new();
+        patterns.insert("token".to_string(), toml::Value::String("[a-zA-Z0-9]+".to_string()));
+        let (matches, feedback) = validate_response_regex(&response, &patterns);
+        assert!(matches, "Should match regex: {:?}", feedback);
+
+        // Test email regex
+        let mut patterns = Table::new();
+        patterns.insert("email".to_string(), toml::Value::String(r".*@.*\..*".to_string()));
+        let (matches, feedback) = validate_response_regex(&response, &patterns);
+        assert!(matches, "Should match email regex: {:?}", feedback);
+
+        // Test numeric regex
+        let mut patterns = Table::new();
+        patterns.insert("user_id".to_string(), toml::Value::String(r"\d+".to_string()));
+        let (matches, feedback) = validate_response_regex(&response, &patterns);
+        assert!(matches, "Should match numeric regex: {:?}", feedback);
+
+        // Test non-matching regex
+        let mut patterns = Table::new();
+        patterns.insert("token".to_string(), toml::Value::String("^[0-9]+$".to_string()));
+        let (matches, feedback) = validate_response_regex(&response, &patterns);
+        assert!(!matches, "Should not match numeric-only regex");
+        assert!(feedback.is_some());
+    }
+
+    #[test]
+    fn test_is_value_reference() {
+        // Valid reference
+        let valid_ref = serde_json::json!({
+            "from": "test_login",
+            "property": "response.token"
+        });
+        assert!(is_value_reference(&valid_ref));
+
+        // Invalid - missing "from"
+        let invalid1 = serde_json::json!({
+            "property": "response.token"
+        });
+        assert!(!is_value_reference(&invalid1));
+
+        // Invalid - missing "property"
+        let invalid2 = serde_json::json!({
+            "from": "test_login"
+        });
+        assert!(!is_value_reference(&invalid2));
+
+        // Invalid - extra field
+        let invalid3 = serde_json::json!({
+            "from": "test_login",
+            "property": "response.token",
+            "extra": "field"
+        });
+        assert!(!is_value_reference(&invalid3));
+
+        // Invalid - not an object
+        let invalid4 = serde_json::json!("just a string");
+        assert!(!is_value_reference(&invalid4));
+    }
+
+    #[test]
+    fn test_resolve_payload_references() -> Result<()> {
+        let mut responses = HashMap::new();
+        responses.insert("test_login".to_string(), serde_json::json!({
+            "access_token": "secret_token_123",
+            "user": {
+                "id": 42
+            }
+        }));
+
+        // Test simple reference
+        let mut payload = serde_json::json!({
+            "auth_token": {
+                "from": "test_login",
+                "property": "access_token"
+            }
+        });
+        resolve_payload_references(&mut payload, &responses)?;
+        assert_eq!(payload["auth_token"], serde_json::json!("secret_token_123"));
+
+        // Test nested reference
+        let mut payload = serde_json::json!({
+            "user_id": {
+                "from": "test_login",
+                "property": "user.id"
+            }
+        });
+        resolve_payload_references(&mut payload, &responses)?;
+        assert_eq!(payload["user_id"], serde_json::json!(42));
+
+        // Test missing reference
+        let mut payload = serde_json::json!({
+            "token": {
+                "from": "nonexistent",
+                "property": "token"
+            }
+        });
+        let result = resolve_payload_references(&mut payload, &responses);
+        assert!(result.is_err());
+
         Ok(())
     }
 }

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -9,7 +9,11 @@ async fn test_examples() -> Result<()> {
 
     let args = Args {
         base_url: Some(server.base_url()),
-        test_files: vec![],
+        test_files: vec![
+            "single_endpoint".to_string(),
+            "login_tests".to_string(),
+            "error_cases".to_string(),
+        ],
         tests_folder: Some(PathBuf::from("examples")),
         timeout: 30,
         json: false,
@@ -67,5 +71,137 @@ async fn test_examples() -> Result<()> {
 
     let result = run_tests(&args).await?;
     assert!(result.success);
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_response_referencing() -> Result<()> {
+    let server = MockServer::start();
+
+    let args = Args {
+        base_url: Some(server.base_url()),
+        test_files: vec!["response_reference".to_string()],
+        tests_folder: Some(PathBuf::from("examples")),
+        timeout: 30,
+        json: false,
+        debug: false
+    };
+
+    // Mock for getting a token
+    server.mock(|when, then| {
+        when.method("POST")
+            .path("/auth/token")
+            .json_body_obj(&serde_json::json!({
+                "client_id": "test_client"
+            }));
+        then.status(200).json_body_obj(&serde_json::json!({
+            "access_token": "abc123xyz",
+            "token_type": "Bearer",
+            "expires_in": 3600
+        }));
+    });
+
+    // Mock for protected endpoint that receives the token
+    server.mock(|when, then| {
+        when.method("GET")
+            .path("/api/protected")
+            .json_body_obj(&serde_json::json!({
+                "auth_token": "abc123xyz"
+            }));
+        then.status(200).json_body_obj(&serde_json::json!({
+            "status": "authorized",
+            "user": "test_user"
+        }));
+    });
+
+    let result = run_tests(&args).await?;
+    assert!(result.success, "Response referencing test failed");
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_regex_matching() -> Result<()> {
+    let server = MockServer::start();
+
+    let args = Args {
+        base_url: Some(server.base_url()),
+        test_files: vec!["regex_matching".to_string()],
+        tests_folder: Some(PathBuf::from("examples")),
+        timeout: 30,
+        json: false,
+        debug: false
+    };
+
+    // Mock for token endpoint
+    server.mock(|when, then| {
+        when.method("POST")
+            .path("/auth/token")
+            .json_body_obj(&serde_json::json!({
+                "client_id": "test_client"
+            }));
+        then.status(200).json_body_obj(&serde_json::json!({
+            "access_token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9",
+            "token_type": "Bearer",
+            "expires_in": 3600
+        }));
+    });
+
+    // Mock for user endpoint with regex-matchable response
+    server.mock(|when, then| {
+        when.method("GET").path("/api/users/42");
+        then.status(200).json_body_obj(&serde_json::json!({
+            "id": 42,
+            "name": "Test User",
+            "email": "test@example.com"
+        }));
+    });
+
+    let result = run_tests(&args).await?;
+    assert!(result.success, "Regex matching test failed");
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_missing_reference_fails() -> Result<()> {
+    let server = MockServer::start();
+
+    // Create a temp directory with a test that references a non-existent test
+    // Using a relative path under the project directory to work around get_test_files behavior
+    let temp_dir = PathBuf::from("test_temp_missing_ref");
+    std::fs::create_dir_all(&temp_dir)?;
+
+    let test_content = r#"
+[test_with_bad_reference]
+method = "GET"
+route = "api/test"
+payload.token = { from = "nonexistent_test", property = "token" }
+expect.http_status = 200
+"#;
+    std::fs::write(temp_dir.join("bad_ref.toml"), test_content)?;
+
+    let args = Args {
+        base_url: Some(server.base_url()),
+        test_files: vec!["bad_ref".to_string()],
+        tests_folder: Some(temp_dir.clone()),
+        timeout: 30,
+        json: false,
+        debug: false
+    };
+
+    server.mock(|when, then| {
+        when.method("GET").path("/api/test");
+        then.status(200).json_body_obj(&serde_json::json!({
+            "result": "ok"
+        }));
+    });
+
+    let result = run_tests(&args).await?;
+
+    // The test should fail because the reference doesn't exist
+    assert!(!result.success, "Test with missing reference should fail");
+
+    // Cleanup
+    std::fs::remove_dir_all(&temp_dir)?;
+
     Ok(())
 }


### PR DESCRIPTION
* Fixes an issue caused by deserializing JSON response values into a `Table` from the `toml` crate. 
* Responses from test runs now use `serde_json::Value` semantics. 
* This is pre-work to support the CI/CD integration milestone (a way to export test results  to JSON).