### PR TITLE
Add -H/--header flag for custom HTTP headers

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@
 use anyhow::{Context, Result};
 use clap::Parser;
 use colored::*;
+use reqwest::header::{HeaderMap, HeaderName, HeaderValue};
 use reqwest::Client;
 use serde::{Deserialize, Serialize};
 use std::{
@@ -45,6 +46,11 @@ pub struct Args {
     /// Output results as JSON (Not implemented yet)
     #[arg(short = 'j', long = "json")]
     pub json: bool,
+
+    /// HTTP headers to include with each request (can be used multiple times)
+    /// Format: "Header-Name: value"
+    #[arg(short = 'H', long = "header", value_name = "HEADER")]
+    pub headers: Vec<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -318,14 +324,33 @@ pub async fn run_test_case(
     Ok(())
 }
 
+fn parse_headers(header_strings: &[String]) -> Result<HeaderMap> {
+    let mut headers = HeaderMap::new();
+    for h in header_strings {
+        let parts: Vec<&str> = h.splitn(2, ':').collect();
+        if parts.len() != 2 {
+            return Err(anyhow::anyhow!("Invalid header format: '{}'. Expected 'Name: value'", h));
+        }
+        let name = HeaderName::from_bytes(parts[0].trim().as_bytes())
+            .with_context(|| format!("Invalid header name: {}", parts[0]))?;
+        let value = HeaderValue::from_str(parts[1].trim())
+            .with_context(|| format!("Invalid header value: {}", parts[1]))?;
+        headers.insert(name, value);
+    }
+    Ok(headers)
+}
+
 pub async fn run_tests(args: &Args) -> Result<TestSuiteResult> {
     let base_url = args
         .base_url
         .clone()
         .unwrap_or_else(|| "http://127.0.0.1:3030".to_string());
 
+    let headers = parse_headers(&args.headers)?;
+
     let client = Client::builder()
         .timeout(Duration::from_secs(args.timeout))
+        .default_headers(headers)
         .build()
         .context("Failed to create HTTP client")?;
 
@@ -536,6 +561,7 @@ mod tests {
             timeout: 30,
             json: false,
             debug: false,
+            headers: vec![],
         };
 
         let files = get_test_files(&args)?;


### PR DESCRIPTION
## Summary

- Add `-H`/`--header` CLI flag for passing custom HTTP headers with each request
- Headers are specified in `"Name: value"` format  
- Flag can be used multiple times to set multiple headers
- Headers are applied as default headers on the HTTP client

## Motivation

Many APIs require authentication via Bearer tokens or custom headers. This change enables Tasty to test authenticated endpoints without needing a proxy or wrapper.

## Example Usage

```bash
# Single header
tasty https://api.example.com -H "Authorization: Bearer mytoken"

# Multiple headers
tasty https://api.example.com -H "Authorization: Bearer token" -H "X-Api-Key: key"
```

## Test plan

- [x] Tested against authenticated API endpoint (Barndoor)
- [x] Verified existing tests still pass
- [x] Verified `--help` shows new flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)